### PR TITLE
fix(core): hover tooltip for multi input

### DIFF
--- a/libs/core/multi-input/multi-input.component.html
+++ b/libs/core/multi-input/multi-input.component.html
@@ -69,6 +69,7 @@
                         [disabled]="disabled"
                         (onCloseClick)="_onTokenClick(option, false, $event)"
                         (onRemove)="_onTokenClick(option, false)"
+                        [title]="option.label"
                     >
                         <span [innerHtml]="option.label"></span>
                     </fd-token>
@@ -122,6 +123,7 @@
                         (click)="_onCheckboxClick(option, $event, idx, true)"
                         (keyup)="_onCheckboxKeyup(option, $event, idx, true)"
                         [selected]="!!option.isSelected"
+                        [title]="option.label"
                     >
                         <fd-checkbox (click)="_onCheckboxClick(option, $event, idx)" [value]="option.isSelected">
                             <!-- TODO -->


### PR DESCRIPTION

closes: https://github.com/SAP/fundamental-ngx/issues/10849

## Description

Added the [title] attribute to <fd-token> & <ng-template #list>

Tested the fix on Windows edge browser. Can safely assume that the fix should work on all modern browsers.

## Screenshots

![10849_hover](https://github.com/NineBit-Computing/fundamental-ngx/assets/149890433/122730e0-b2a1-40f1-b62e-977c7cb4de2c)

#### Please check whether the PR fulfills the following requirements

##### During Implementation

1. Visual Testing:

-   [x] visual misalignments/updates
-   [x] responsiveness(resize)
-   [x] States - hover/disabled/focused/active/on click/selected/selected hover/press state
-   [x] Text Truncation

